### PR TITLE
prefix boring symbols with BORINGSSL_PREFIX to avoid collisions

### DIFF
--- a/boring-sys/build/main.rs
+++ b/boring-sys/build/main.rs
@@ -201,12 +201,38 @@ fn get_boringssl_platform_output_path(config: &Config) -> String {
     }
 }
 
+/// Returns the symbol prefix to apply via boringssl's BORINGSSL_PREFIX
+/// mechanism, or `None` when prefixing should be skipped.
+///
+/// Prefixing rewrites every boringssl symbol (e.g. `SSL_new` ->
+/// `rama_boring_<version>_SSL_new`). This makes it possible to use
+/// this in combination with openssl without issues
+fn build_prefix(config: &Config) -> Option<String> {
+    if config.env.docs_rs {
+        return None;
+    }
+    if config.env.path.is_some() {
+        return None;
+    }
+
+    Some(format!(
+        "rama_boring_{}",
+        env!("CARGO_PKG_VERSION")
+            .replace('.', "_")
+            .replace('-', "_")
+    ))
+}
+
 /// Returns a new `cmake::Config` for building BoringSSL.
 ///
 /// It will add platform-specific parameters if needed.
 fn get_boringssl_cmake_config(config: &Config) -> cmake::Config {
     let src_path = get_boringssl_source_path(config);
     let mut boringssl_cmake = cmake::Config::new(src_path);
+
+    if let Some(prefix) = build_prefix(config) {
+        boringssl_cmake.define("BORINGSSL_PREFIX", &prefix);
+    }
 
     if config.env.cmake_toolchain_file.is_some() {
         return boringssl_cmake;
@@ -749,6 +775,14 @@ fn generate_bindings(config: &Config) {
             .clang_arg(sysroot.display().to_string());
     }
 
+    if let Some(prefix) = build_prefix(config) {
+        builder = builder
+            .clang_arg(format!("-DBORINGSSL_PREFIX={prefix}"))
+            .parse_callbacks(Box::new(StripPrefixCallback {
+                prefix: format!("{prefix}_"),
+            }));
+    }
+
     let headers = [
         "aes.h",
         "asn1_mac.h",
@@ -807,4 +841,23 @@ fn ensure_err_lib_enum_is_named(source_code: &mut Vec<u8>) {
         format!("\n/// Newtype for [`ERR_LIB_SSL`] constants\npub use {enum_type} as ErrLib;\n")
             .as_bytes(),
     );
+}
+
+/// bindgen callback that strips the BORINGSSL_PREFIX from generated Rust
+/// identifiers while keeping the the prefix on the C side.
+#[derive(Debug)]
+struct StripPrefixCallback {
+    prefix: String,
+}
+
+impl bindgen::callbacks::ParseCallbacks for StripPrefixCallback {
+    fn generated_name_override(
+        &self,
+        item_info: bindgen::callbacks::ItemInfo<'_>,
+    ) -> Option<String> {
+        item_info
+            .name
+            .strip_prefix(self.prefix.as_str())
+            .map(String::from)
+    }
 }

--- a/boring-sys/build/main.rs
+++ b/boring-sys/build/main.rs
@@ -775,11 +775,7 @@ fn generate_bindings(config: &Config) {
     }
 
     if let Some(prefix) = build_prefix(config) {
-        builder = builder
-            .clang_arg(format!("-DBORINGSSL_PREFIX={prefix}"))
-            .parse_callbacks(Box::new(StripPrefixCallback {
-                prefix: format!("{prefix}_"),
-            }));
+        builder = builder.clang_arg(format!("-DBORINGSSL_PREFIX={prefix}"));
     }
 
     let headers = [
@@ -825,7 +821,30 @@ fn generate_bindings(config: &Config) {
         .write(Box::new(&mut source_code))
         .expect("Couldn't serialize bindings!");
     ensure_err_lib_enum_is_named(&mut source_code);
+    if build_prefix(config).is_some() {
+        make_link_names_target_portable(&mut source_code);
+    }
     fs::write(config.out_dir.join("bindings.rs"), source_code).expect("Couldn't write bindings!");
+}
+
+/// Rewrite `#[link_name = "\u{1}<mangled>"]` attributes so the link name is
+/// just the bare C symbol. This is needed so it is consistent everywhere and
+/// not dependent on which host type we ran the build on.
+fn make_link_names_target_portable(source_code: &mut Vec<u8>) {
+    let host_adds_underscore = cfg!(any(
+        target_vendor = "apple",
+        all(target_arch = "x86", target_os = "windows"),
+    ));
+    let link_name = "link_name = \"";
+    let escape = if host_adds_underscore {
+        "\\u{1}_"
+    } else {
+        "\\u{1}"
+    };
+    let needle = [link_name, escape].concat();
+    let src = String::from_utf8(std::mem::take(source_code))
+        .expect("bindgen output should be valid UTF-8");
+    *source_code = src.replace(&needle, link_name).into_bytes();
 }
 
 /// err.h has anonymous `enum { ERR_LIB_NONE = 1 }`, which makes a dodgy `_bindgen_ty_1` name
@@ -840,23 +859,4 @@ fn ensure_err_lib_enum_is_named(source_code: &mut Vec<u8>) {
         format!("\n/// Newtype for [`ERR_LIB_SSL`] constants\npub use {enum_type} as ErrLib;\n")
             .as_bytes(),
     );
-}
-
-/// bindgen callback that strips the BORINGSSL_PREFIX from generated Rust
-/// identifiers while keeping the the prefix on the C side.
-#[derive(Debug)]
-struct StripPrefixCallback {
-    prefix: String,
-}
-
-impl bindgen::callbacks::ParseCallbacks for StripPrefixCallback {
-    fn generated_name_override(
-        &self,
-        item_info: bindgen::callbacks::ItemInfo<'_>,
-    ) -> Option<String> {
-        item_info
-            .name
-            .strip_prefix(self.prefix.as_str())
-            .map(String::from)
-    }
 }

--- a/boring-sys/build/main.rs
+++ b/boring-sys/build/main.rs
@@ -617,8 +617,7 @@ fn built_boring_source_path(config: &Config) -> &PathBuf {
             cfg.env("CMAKE_BUILD_PARALLEL_LEVEL", num_jobs);
         }
 
-        cfg.build_target("ssl").build();
-        cfg.build_target("crypto").build()
+        cfg.build_target("ssl").build()
     })
 }
 

--- a/boring-sys/build/main.rs
+++ b/boring-sys/build/main.rs
@@ -215,12 +215,11 @@ fn build_prefix(config: &Config) -> Option<String> {
         return None;
     }
 
-    Some(format!(
-        "rama_boring_{}",
-        env!("CARGO_PKG_VERSION")
-            .replace('.', "_")
-            .replace('-', "_")
-    ))
+    let version: String = env!("CARGO_PKG_VERSION")
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    Some(format!("rama_boring_{version}"))
 }
 
 /// Returns a new `cmake::Config` for building BoringSSL.
@@ -548,6 +547,11 @@ fn ensure_patches_applied(config: &Config) -> io::Result<()> {
     println!("cargo:info=applying boringssl cmake cleanup patch");
     apply_patch(config, "rama_boringssl_cmake.patch")?;
 
+    // BoringSSL's `verify_boringssl_prefix` audit otherwise requires Go at
+    // cmake configure time whenever BORINGSSL_PREFIX is set.
+    println!("cargo:info=applying boringssl prefix patch (drop Go-dependent audit)");
+    apply_patch(config, "rama_boring_prefix.patch")?;
+
     Ok(())
 }
 
@@ -774,7 +778,8 @@ fn generate_bindings(config: &Config) {
             .clang_arg(sysroot.display().to_string());
     }
 
-    if let Some(prefix) = build_prefix(config) {
+    let prefix = build_prefix(config);
+    if let Some(prefix) = &prefix {
         builder = builder.clang_arg(format!("-DBORINGSSL_PREFIX={prefix}"));
     }
 
@@ -821,7 +826,7 @@ fn generate_bindings(config: &Config) {
         .write(Box::new(&mut source_code))
         .expect("Couldn't serialize bindings!");
     ensure_err_lib_enum_is_named(&mut source_code);
-    if build_prefix(config).is_some() {
+    if prefix.is_some() {
         make_link_names_target_portable(&mut source_code);
     }
     fs::write(config.out_dir.join("bindings.rs"), source_code).expect("Couldn't write bindings!");
@@ -844,6 +849,16 @@ fn make_link_names_target_portable(source_code: &mut Vec<u8>) {
     let needle = [link_name, escape].concat();
     let src = String::from_utf8(std::mem::take(source_code))
         .expect("bindgen output should be valid UTF-8");
+
+    let matches = src.matches(needle.as_str()).count();
+    assert!(
+        matches > 0,
+        "make_link_names_target_portable: expected to find at least one \
+         `#[link_name = \"\\u{{1}}{u}…\"]` attribute in bindgen output but \
+         found none. Bindgen's serialisation format may have changed; \
+         re-evaluate this post-processor.",
+        u = if host_adds_underscore { "_" } else { "" },
+    );
     *source_code = src.replace(&needle, link_name).into_bytes();
 }
 

--- a/boring-sys/patches/rama_boring_prefix.patch
+++ b/boring-sys/patches/rama_boring_prefix.patch
@@ -1,0 +1,36 @@
+Drop BoringSSL's BORINGSSL_PREFIX symbol-audit step.
+
+When BORINGSSL_PREFIX is set, upstream BoringSSL's CMakeLists.txt calls
+require_go() and adds a `verify_boringssl_prefix ALL` custom target that
+runs `util/audit_symbols.go` against libcrypto to check no unprefixed
+symbol slipped through. That makes Go a hard build-time dependency of
+rama-boring-sys at the cmake configure step — even though we never build
+the verify target (we only build `ssl`). We trust the prefix mechanism
+itself, so just delete the block.
+
+This patch is applied after rama_boringssl_cmake.patch, so line numbers
+reflect the post-cmake-patch view of CMakeLists.txt.
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -627,19 +627,6 @@
+   set(HANDSHAKER_ARGS "-handshaker-path" $<TARGET_FILE:handshaker>)
+ endif()
+ 
+-if(BORINGSSL_PREFIX)
+-  require_go()
+-  add_custom_target(
+-    verify_boringssl_prefix ALL
+-    COMMENT "Verifying symbol prefixing"
+-    COMMAND ${GO_EXECUTABLE}
+-            run ${CMAKE_CURRENT_SOURCE_DIR}/util/audit_symbols.go
+-            -ignore-symbols-with ${BORINGSSL_PREFIX}
+-            $<TARGET_FILE:crypto>
+-    DEPENDS crypto
+-    USES_TERMINAL
+-  )
+-endif()
+ 
+ if(INSTALL_ENABLED)
+   install(TARGETS crypto ssl EXPORT OpenSSLTargets)


### PR DESCRIPTION
Prefix boringssl symbols similar to how aws-lc does it. By prefixing them it will become possible to use rama with other dependencies that need/pull in openssl or another boringssl version.