### PR TITLE
Support newer windows builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ bindgen = { version = "0.72.0", default-features = false, features = [
 bitflags = "2.9"
 brotli = "8.0"
 bytes = "1"
-cmake = "0.1.54"
+cmake = "0.1.57"
 foreign-types = "0.5"
 fs_extra = "1.3.0"
 fslock = "0.2"

--- a/boring-sys/build/main.rs
+++ b/boring-sys/build/main.rs
@@ -341,7 +341,9 @@ fn get_boringssl_cmake_config(config: &Config) -> cmake::Config {
             if config.target.contains("-pc-windows-gnu") {
                 boringssl_cmake.define("CMAKE_CXX_STANDARD", "17");
             } else if config.target.ends_with("-pc-windows-msvc") {
-                boringssl_cmake.generator("Visual Studio 17 2022");
+                // Don't pin a Visual Studio generator: let cmake-rs auto detect the installed
+                // version so the build keeps working across ci updates / env updates.
+                // If newer Visual Studio's start to throw errors: updating `cmake` crate should fix it.
                 if config.target_arch == "x86" {
                     boringssl_cmake.define("CMAKE_GENERATOR_PLATFORM", "Win32");
                 } else if config.target_arch == "aarch64" {


### PR DESCRIPTION
Support passing in windows generator so newer version are supported (github has updated CI runners)

Fix this in CI
```

  running: "cmake" "D:\\a\\rama-boring\\rama-boring\\target\\i686-pc-windows-msvc\\debug\\build\\rama-boring-sys-7f3c54583151e941\\out\\boringssl" "-B" "D:\\a\\rama-boring\\rama-boring\\target\\i686-pc-windows-msvc\\debug\\build\\rama-boring-sys-7f3c54583151e941\\out\\build" "-Thost=x86" "-AWin32" "-G" "Visual Studio 17 2022" "-DBORINGSSL_PREFIX=rama_boring_0_6_3" "-DCMAKE_C_COMPILER=cl" "-DCMAKE_CXX_COMPILER=cl" "-DOPENSSL_NO_ASM=TRUE" "-DCMAKE_GENERATOR_PLATFORM=Win32" "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL" "-DCMAKE_C_FLAGS_DEBUG=/Zi /Ob0 /Od /RTC1" "-DCMAKE_CXX_FLAGS_DEBUG=/Zi /Ob0 /Od /RTC1" "-DCMAKE_POSITION_INDEPENDENT_CODE=ON" "-DCMAKE_SYSTEM_NAME=Windows" "-DCMAKE_SYSTEM_PROCESSOR=X86" "-DCMAKE_INSTALL_PREFIX=D:\\a\\rama-boring\\rama-boring\\target\\i686-pc-windows-msvc\\debug\\build\\rama-boring-sys-7f3c54583151e941\\out" "-DCMAKE_C_FLAGS= -nologo -MD -Brepro -W0" "-DCMAKE_CXX_FLAGS= -nologo -MD -Brepro -W0" "-DCMAKE_ASM_FLAGS= -nologo -MD -Brepro -W0" "-DCMAKE_BUILD_TYPE=Debug"
  CMake Error at CMakeLists.txt:18 (project):
    Generator

      Visual Studio 17 2022

    could not find any instance of Visual Studio.


```